### PR TITLE
fix: make freeze guard resilient to missing git refs

### DIFF
--- a/scripts/boot3-freeze-guard.sh
+++ b/scripts/boot3-freeze-guard.sh
@@ -36,7 +36,26 @@ case "$BATCH" in
     ;;
 esac
 
-changed_files="$(git diff --name-only "$BASE_REF" "$TARGET_REF" -- src/main/java || true)"
+valid_base_ref=1
+valid_target_ref=1
+
+if ! git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null; then
+  valid_base_ref=0
+fi
+
+if ! git rev-parse --verify --quiet "$TARGET_REF^{commit}" >/dev/null; then
+  valid_target_ref=0
+fi
+
+if [[ "$valid_base_ref" -eq 0 || "$valid_target_ref" -eq 0 ]]; then
+  echo "[freeze-guard] WARN: Unable to resolve revision(s)." >&2
+  [[ "$valid_base_ref" -eq 0 ]] && echo "[freeze-guard]  - invalid base_ref: $BASE_REF" >&2
+  [[ "$valid_target_ref" -eq 0 ]] && echo "[freeze-guard]  - invalid target_ref: $TARGET_REF" >&2
+  echo "[freeze-guard] Fallback: evaluating only local working tree Java changes." >&2
+  changed_files="$(git status --porcelain -- src/main/java | awk '{print $2}' || true)"
+else
+  changed_files="$(git diff --name-only "$BASE_REF" "$TARGET_REF" -- src/main/java || true)"
+fi
 
 if [[ -z "$changed_files" ]]; then
   echo "[freeze-guard] No Java source changes detected in range $BASE_REF..$TARGET_REF"


### PR DESCRIPTION
### Motivation
- Avoid noisy `fatal: bad revision` failures when `base_ref`/`target_ref` (e.g. `origin/main`) are not available locally, so the freeze-check remains actionable in shallow/offline environments.
- Provide a deterministic fallback behavior that still lets reviewers see local Java changes and an explicit WARN instead of raw git errors.

### Description
- Add ref existence checks with `git rev-parse --verify` and track `valid_base_ref` / `valid_target_ref` to determine whether refs are resolvable.
- When refs cannot be resolved, fallback to collecting changed Java files from the local working tree via `git status --porcelain -- src/main/java | awk '{print $2}'`, otherwise retain the original `git diff --name-only` behavior; all batch rules and gate hints remain unchanged.

### Testing
- Ran `./scripts/boot3-freeze-guard.sh C origin/main HEAD`, which completed, emitted a WARN about unresolved refs, and exited `0` (fallback path exercised).
- Performed a syntax check with `bash -n scripts/boot3-freeze-guard.sh`, which succeeded.
- Attempted `./scripts/test-gate.sh smoke`, but it failed due to Maven parent POM resolution being blocked by network/mirror access, so full smoke tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce4956d944832799a63247112b1d7b)